### PR TITLE
Added method to ask for active checks

### DIFF
--- a/pyzabbix/__init__.py
+++ b/pyzabbix/__init__.py
@@ -1,4 +1,4 @@
 from .api import ZabbixAPI, ZabbixAPIException, ssl_context_compat
-from .sender import ZabbixMetric, ZabbixSender, ZabbixResponse
+from .sender import ZabbixMetric, ZabbixSender, ZabbixResponse, ZabbixActiveChecksResponse, ZabbixCheck
 
 __version__ = '1.1.3'

--- a/pyzabbix/sender.py
+++ b/pyzabbix/sender.py
@@ -131,6 +131,66 @@ class ZabbixMetric(object):
         return result
 
 
+class ZabbixActiveChecksResponse(object):
+    """The :class:`ZabbixActiveChecksResponse` contains the parsed response from Zabbix.
+    """
+    def __init__(self):
+        self.checks = None
+
+    def __repr__(self):
+        """Represent detailed ZabbixActiveChecksResponse view."""
+        if self.checks is None:
+            return ''
+        else:
+            return "[%s]" % ", ".join([ch.__repr__() for ch in self.checks])
+
+    def parse(self, response):
+        """Parse zabbix response for active checks."""
+        self.checks = []
+        data = response.get('data')
+        for o in data:
+            ch = ZabbixCheck(
+                o.get('key'),
+                o.get('delay'),
+                o.get('lastlogsize'),   # optional in 2.2; required in 2.4, 3.0, 3.2, 3.4
+                o.get('mtime'))         # unused in 3.2;   required in 2.4, 3.0, 3.2, 3.4
+            self.checks.append(ch)
+
+
+class ZabbixCheck(object):
+    """The :class:`ZabbixCheck` contains one active check the Zabbix server would like.
+
+    :type key: str
+    :param key: Key by which you will identify this metric.
+
+    :type delay: int
+    :param delay: Period (in seconds) to collect this metric.
+
+    :type lastlogsize: int
+    :param lastlogsize: Point in the log file already known by the server.
+
+    :type mtime: int
+    :param mtime: Last time the server heard about this metric.
+
+    >>> from pyzabbix import ZabbixCheck
+    >>> ZabbixCheck('cpu[usage]', 60, 0, 0)
+    """
+
+    def __init__(self, key, delay, lastlogsize, mtime):
+        self.key = str(key)
+        self.delay = delay
+        self.lastlogsize = lastlogsize
+        self.mtime = mtime
+
+    def __repr__(self):
+        """Represent detailed ZabbixCheck view."""
+
+        result = json.dumps(self.__dict__)
+        logger.debug('%s: %s', self.__class__.__name__, result)
+
+        return result
+
+
 class ZabbixSender(object):
     """The :class:`ZabbixSender` send metrics to Zabbix server.
 
@@ -385,3 +445,58 @@ class ZabbixSender(object):
         for m in range(0, len(metrics), self.chunk_size):
             result.parse(self._chunk_send(metrics[m:m + self.chunk_size]))
         return result
+
+    def _create_active_checks_request(self, host):
+        """Create a formatted request to zabbix from a host name.
+
+        :type host: str
+        :param host: The host to ask about
+
+        :rtype: str
+        :return: Formatted zabbix request
+        """
+        request = '{"request":"active checks","host":"%s"}' % host
+        request = request.encode("utf-8")
+        logger.debug('Request: %s', request)
+        return request
+
+    def send_active_checks(self, host):
+        """Get active checks from the zabbix server.
+
+        :type host: str
+        :param host: host to ask about
+
+        :rtype: :class:`pyzabbix.sender.ZabbixActiveChecksResponse`
+        :return: Parsed response from Zabbix Server
+        """
+        request = self._create_active_checks_request(host)
+        packet = self._create_packet(request)
+
+        for host_addr in self.zabbix_uri:
+            logger.debug('Sending data to %s', host_addr)
+
+            # create socket object
+            connection = socket.socket()
+
+            # server and port must be tuple
+            connection.connect(host_addr)
+
+            try:
+                connection.sendall(packet)
+            except Exception as err:
+                # In case of error we should close connection,
+                # otherwise we will close it after data will be received.
+                connection.close()
+                raise Exception(err)
+
+            response = self._get_response(connection)
+            logger.debug('%s response: %s', host_addr, response)
+
+            if response and response.get('response') != 'success':
+                logger.debug('Response error: %s}', response)
+                raise Exception(response)
+
+        result = ZabbixActiveChecksResponse()
+        result.parse(response)
+        return result
+


### PR DESCRIPTION
Asks the Zabbix server for the active checks that are needed for a given host, following the protocol documented here: https://www.zabbix.com/documentation/3.4/manual/appendix/items/activepassive?s[]=agent&s[]=protocol

This PR includes a few unit tests for the new methods. I also wrote a functional test (not included here), but I wasn't sure how to update the Zabbix test data to make it pass. If you don't mind getting the test to pass yourself, let me know and I'll add it as a separate commit.

Thanks for this project!