### PR TITLE
allows to provide zabbix sender with a socket wrapper to allow secure connection

### DIFF
--- a/pyzabbix/sender.py
+++ b/pyzabbix/sender.py
@@ -150,6 +150,10 @@ class ZabbixSender(object):
 
     :type chunk_size: int
     :param chunk_size: Number of metrics send to the server at one time
+    
+    :type socket_wrapper: function
+    :param socket_wrapper: to provide a socket wrapper function to be used to wrap the socket connection to zabbix
+
 
     >>> from pyzabbix import ZabbixMetric, ZabbixSender
     >>> metrics = []
@@ -163,10 +167,12 @@ class ZabbixSender(object):
                  zabbix_server='127.0.0.1',
                  zabbix_port=10051,
                  use_config=None,
-                 chunk_size=250):
+                 chunk_size=250,
+                 socket_wrapper=None
+                 ):
 
         self.chunk_size = chunk_size
-
+        self.socket_wrapper = socket_wrapper
         if use_config:
             self.zabbix_uri = self._load_from_config(use_config)
         else:
@@ -349,7 +355,11 @@ class ZabbixSender(object):
             logger.debug('Sending data to %s', host_addr)
 
             # create socket object
-            connection = socket.socket()
+            connection_ = socket.socket()
+            if self.socket_wrapper:
+                connection = self.socket_wrapper(connection_)
+            else:
+                connection = connection_
 
             # server and port must be tuple
             connection.connect(host_addr)


### PR DESCRIPTION
as far a i saw py-zabbix did not support any secure connection options,
i added an option that allows wrapping the socket connection with an encryption layer.

this option does not support configuration files, but seems the simplest change to support this requirement.

usage should be similar to the below
`
from pyzabbix import ZabbixSender
import ssl
secure_connection_option = dict(..)
zabbix_sender = ZabbixSender(zabbix_server=zabbix_server,
                             zabbix_port=zabbix_port,
                             socket_wrapper=lambda sock:ssl.wrap_socket(sock,**secure_connection_option)
                            )

`