### PR TITLE
Fix travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 env:
   - ZABBIX_VERSION: 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
 
 script:
   - while ! nc -z 127.0.0.1 10051; do sleep 1; done
+  - sleep 60
   - pep8 pyzabbix/
   - pep8 tests/*.py
   - coverage run setup.py test

--- a/tests/data/Zabbix2/Dockerfile
+++ b/tests/data/Zabbix2/Dockerfile
@@ -1,4 +1,4 @@
-FROM  mysql
+FROM  mysql:5
 MAINTAINER Maksim Syomochkin <maksim77ster@gmail.com>
 ENV MYSQL_ROOT_PASSWORD=root_pwd \
   MYSQL_DATABASE=zabbix \

--- a/tests/data/Zabbix2/Dockerfile
+++ b/tests/data/Zabbix2/Dockerfile
@@ -1,5 +1,5 @@
 FROM  mysql:5
-MAINTAINER Maksim Syomochkin <maksim77ster@gmail.com>
+LABEL maintainer="Maksim Syomochkin <maksim77ster@gmail.com>"
 ENV MYSQL_ROOT_PASSWORD=root_pwd \
   MYSQL_DATABASE=zabbix \
   MYSQL_USER=zabbix \

--- a/tests/data/Zabbix3/Dockerfile
+++ b/tests/data/Zabbix3/Dockerfile
@@ -1,4 +1,4 @@
-FROM  mysql
+FROM  mysql:5
 MAINTAINER Maksim Syomochkin <maksim77ster@gmail.com>
 ENV MYSQL_ROOT_PASSWORD=root_pwd \
   MYSQL_DATABASE=zabbix \

--- a/tests/data/Zabbix3/Dockerfile
+++ b/tests/data/Zabbix3/Dockerfile
@@ -1,5 +1,5 @@
 FROM  mysql:5
-MAINTAINER Maksim Syomochkin <maksim77ster@gmail.com>
+LABEL maintainer="Maksim Syomochkin <maksim77ster@gmail.com>"
 ENV MYSQL_ROOT_PASSWORD=root_pwd \
   MYSQL_DATABASE=zabbix \
   MYSQL_USER=zabbix \


### PR DESCRIPTION
- [x] Fixed the mysql version used in tests
- [x] Added pause before running tests. Without this, the tests for the version of Zabbix 2 fail. Probably running the container to the working state takes more time than in the case of version 3.
- [x] Added Python 3.6 to possible versions (3.7 not currently available in Travis)