### PR TITLE
Changed ZabbixAPIException() to return short error messages as well

### DIFF
--- a/pyzabbix/api.py
+++ b/pyzabbix/api.py
@@ -255,7 +255,7 @@ class ZabbixAPI(object):
             err.update({'json': str(request_json)})
             msg_str = "Error {code}: {message}, {data} while sending {json}"
             msg = msg_str.format(**err)
-            raise ZabbixAPIException(msg, err['code'])
+            raise ZabbixAPIException(msg, err['code'], err)
 
         return res_json
 


### PR DESCRIPTION
Hi! Thanks for the module, I like its clean and simple design of basically single do_request call. 👍 

I faced a problem though that it's quite impossible to return simple error message when _ZabbixAPIException(msg, err['code'])_ is raised if Zabbix returned an error in JSON.

err['code'] is not informative. And here is what I get if print `msg` if I fail to user.login properly:
```
Error -32602: Invalid params., Login name or password is incorrect. while sending {'params': {'password': 'zabbix', 'user': '123'}, 'jsonrpc': '2.0', 'method': 'user.login', 'id': '1'}
```
First it's long and has raw JSON data and second it shows sensitive data like password. All I actually wanted is to print `Login name or password is incorrect`

Another example is when I try to import a template with `configuration.import`. Here is what I would get in `msg` if configuration.import fails for some reason:
```
Error -32500: Application error., Cannot read XML: (68) StartTag: invalid element name [Line: 3 | Column: 5]. while sending {'params': {u'rules': {u'templates': {u'createMissing': True, u'updateExisting': True}, u'screens': {u'createMissing': True, u'updateExisting': True}, u'graphs': {u'createMissing': True, u'deleteMissing': True, u'updateExisting': True}, u'triggers': {u'createMissing': True, u'deleteMissing': True, u'updateExisting': True}, u'items': {u'createMissing': True, u'deleteMissing': True, u'updateExisting': True},
u'maps': {u'createMissing': True, u'updateExisting': True}, u'valueMaps': {u'createMissing': True, u'updateExisting': True}, u'templateLinkage': {u'createMissing': True}, u'applications': {u'createMissing': True, u'deleteMissing': True}, u'hosts': {u'createMissing':
True, u'updateExisting': True}, u'groups': {u'createMissing': True}, u'images': {u'createMissing': True, u'updateExisting': True}, u'discoveryRules': {u'createMissing': True, u'deleteMissing': True, u'updateExisting': True}, u'templateScreens': {u'createMissing': True, u'deleteMissing': True, u'updateExisting': True}}, u'source': '<?xml version="1.0" encoding="UTF-8"?>\n<zabbix_export>\n   <>3.4</version>\n   <date>2015-12-30T14:41:30Z</date>\n   <groups>\n      <group>\n         <name>Templates/Operating Systems</name>\n      </group>\n   </groups>\n   <templates>\n      <template>\n         <template>Template OS Linux SNMPv2</template>\n         <name>Template OS Linux SNMPv2</name>\n         <description>Template OS Linux version: 0.15</description>\n         <groups>\n            <group>\n               <name>Templates/Operating Systems</name>\n            </group>\n
  </groups>\n         <applications/>\n         <items/>\n         <discovery_rules/>\n
       <httptests/>\n         <macros/>\n         <templates>\n            <template>\n
             <name>Template Module EtherLike-MIB SNMPv2</name>\n            </template>\n            <template>\n               <name>Template Module Generic SNMPv2</name>\n
       </template>\n            <template>\n               <name>Template Module HOST-RESOURCES-MIB SNMPv2</name>\n            </template>\n            <template>\n
 <name>Template Module Interfaces SNMPv2</name>\n            </template>\n         </templates>\n         <screens/>\n      </template>\n   </templates>\n   <graphs/>\n   <triggers/>\n   <value_maps/>\n</zabbix_export>\n', u'format': u'xml'}, 'jsonrpc': '2.0', 'method': 'configuration.import', 'auth': u'c6ce5789735931733d1f064e9c5ae1ba', 'id': '1'}
```
Again, **too** long. and sensitive data is included (auth). All I wanted is string that simply explains why this template cannot be imported: `Cannot read XML: (68) StartTag: invalid element name [Line: 3 | Column: 5]. ` 


According to https://www.zabbix.com/documentation/3.4/manual/api#error_handling
those short error messages are provided by Zabbix itself and they are contained in `data` JSON string.

Instead of parsing `msg` back to the parts, in my pull request I added `err` third turple element to actually access not only long `msg` formatted string or err['code'] but also 
original `data` , `message` JSON strings that are provided by Zabbix. `json` is also included that contains original request.


With this change in place, in my own scripts I can now do it as simple as this:

```python
    try:
        zapi.do_request('configuration.import', params)
    except ZabbixAPIException as err:
        sys.exit(err[2]['data'])
```

Please consider to merge. Tell me if you want this to be implemented in some other way.