### PR TITLE
better exception support

### DIFF
--- a/pyzabbix/api.py
+++ b/pyzabbix/api.py
@@ -45,8 +45,14 @@ class ZabbixAPIException(Exception):
     :32602: Invalid params (eg already exists)
     :32500: No permissions
     """
-    pass
-
+    def __init__(self, *args):
+        super(Exception, self).__init__(*args)
+        if len(args) == 1 and isinstance(args[0], dict):
+            self.error = args[0]
+            self.message = self.error['message']
+            self.code = self.error['code']
+            self.data = self.error['data']
+            self.json = self.error['json']
 
 class ZabbixAPIObjectClass(object):
     """ZabbixAPI Object class.
@@ -253,9 +259,7 @@ class ZabbixAPI(object):
         if 'error' in res_json:
             err = res_json['error'].copy()
             err.update({'json': str(request_json)})
-            msg_str = "Error {code}: {message}, {data} while sending {json}"
-            msg = msg_str.format(**err)
-            raise ZabbixAPIException(msg, err['code'])
+            raise ZabbixAPIException(err)
 
         return res_json
 

--- a/pyzabbix/api.py
+++ b/pyzabbix/api.py
@@ -54,6 +54,7 @@ class ZabbixAPIException(Exception):
             self.data = self.error['data']
             self.json = self.error['json']
 
+
 class ZabbixAPIObjectClass(object):
     """ZabbixAPI Object class.
 


### PR DESCRIPTION
@v-zhuravlev

That is what I mean. I think this should support both previous and new versions. And you should be able do:
```python
  try:
    zapi.do_request('configuration.import', params)
  except ZabbixAPIException as err:
    sys.exit(err.message)
```