### PR TITLE
Fallback to Server if ServerActive is not specified

### DIFF
--- a/pyzabbix/sender.py
+++ b/pyzabbix/sender.py
@@ -223,11 +223,7 @@ class ZabbixSender(object):
         with open(config_file, 'r') as f:
             config_file_data = "[root]\n" + f.read()
 
-        default_params = {
-            'ServerActive': '127.0.0.1:10051',
-        }
-
-        params = dict(defaults=default_params)
+        params = {}
 
         try:
             # python2
@@ -244,7 +240,13 @@ class ZabbixSender(object):
         config_file_fp = StringIO(config_file_data)
         config = configparser.RawConfigParser(**params)
         config.readfp(config_file_fp)
-        zabbix_serveractives = config.get('root', 'ServerActive')
+        if config.has_option('root', 'ServerActive'):
+            zabbix_serveractives = config.get('root', 'ServerActive')
+        elif config.has_option('root', 'Server'):
+            zabbix_serveractives = config.get('root', 'Server')
+        else:
+            zabbix_serveractives = '127.0.0.1:10051'
+                             
         result = []
         for serverport in zabbix_serveractives.split(','):
             if ':' not in serverport:

--- a/pyzabbix/sender.py
+++ b/pyzabbix/sender.py
@@ -240,6 +240,7 @@ class ZabbixSender(object):
         config_file_fp = StringIO(config_file_data)
         config = configparser.RawConfigParser(**params)
         config.readfp(config_file_fp)
+        # Prefer ServerActive, then try Server and fallback to defaults
         if config.has_option('root', 'ServerActive'):
             zabbix_serveractives = config.get('root', 'ServerActive')
         elif config.has_option('root', 'Server'):

--- a/pyzabbix/sender.py
+++ b/pyzabbix/sender.py
@@ -246,7 +246,7 @@ class ZabbixSender(object):
             zabbix_serveractives = config.get('root', 'Server')
         else:
             zabbix_serveractives = '127.0.0.1:10051'
-                             
+
         result = []
         for serverport in zabbix_serveractives.split(','):
             if ':' not in serverport:


### PR DESCRIPTION
The fix for https://github.com/adubkov/py-zabbix/issues/60 breaks usage
if no ServerActive is confiugred, but Server is.