### PR TITLE
Support of automatic user.logout using with statement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,32 @@ ZabbixAPI
     hostnames1 = [host['host'] for host in result1]
     hostnames2 = [host['host'] for host in result2['result']]
 
+    # Logout from Zabbix
+    zapi.user.logout()
+
+Or use 'with' statement to logout automatically:
+
+.. code:: python
+
+    from pyzabbix.api import ZabbixAPI
+
+    # Create ZabbixAPI class instance
+    with ZabbixAPI(url='https://localhost/zabbix/', user='admin', password='zabbix') as zapi
+
+        # Get all monitored hosts
+        result1 = zapi.host.get(monitored_hosts=1, output='extend')
+
+        # Get all disabled hosts
+        result2 = zapi.do_request('host.get',
+                                {
+                                    'filter': {'status': 1},
+                                    'output': 'extend'
+                                })
+
+        # Filter results
+        hostnames1 = [host['host'] for host in result1]
+        hostnames2 = [host['host'] for host in result2['result']]
+
 ZabbixSender
 ~~~~~~~~~~~~
 

--- a/pyzabbix/api.py
+++ b/pyzabbix/api.py
@@ -200,6 +200,21 @@ class ZabbixAPI(object):
         else:
             self.auth = self.user.login(user=user, password=password)
 
+    def _logout(self):
+        """Do logout from zabbix server."""
+
+        if self.auth:
+            logger.debug("ZabbixAPI.logout()")
+
+            if self.user.logout():
+                self.auth = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self._logout()
+
     def api_version(self):
         """Return version of server Zabbix API.
 


### PR DESCRIPTION
Hi!

I suggest to add support for automatic logout using Python [context managers](https://docs.python.org/3/reference/datamodel.html#context-managers)


Currently, it is  necessary to do `user.logout` [call ](https://zabbix.com/documentation/current/manual/api/reference/user/logout) manually, for example in python scripts, othewise, you will get a lots of unused access tokens active in zabbix sessions table.

So with this patch, you would access Zabbix just like opening file in python, without worrying that you need to logout, this will happen automatically:
```python
with ZabbixAPI(url='http://localhost/', user='Admin', password='zabbix') as zapi:
    # Get all monitored hosts 
    print(zapi.host.get())
```
If for some reason (like reusing this token)  you don't want to logout, you can use library the other way.

P.S.
- sessions table, without user logout:

```
mysql> select * from sessions;
+----------------------------------+--------+------------+--------+
| sessionid                        | userid | lastaccess | status |
+----------------------------------+--------+------------+--------+
| 79726790b5b216ab40865a7e11aacd75 |      1 | 1544715413 |      0 |
| f39a4d69ececaec19e09bff244c6fee3 |      1 | 1544715414 |      0 |
| cfa506980201c3d28badfdc4c6733fad |      1 | 1544715415 |      0 |
| b24a6b6da71ef9fd6dd8f59fb701c72e |      1 | 1544715416 |      0 |
| 4b2772d17aac9ea3217a1e80032fab83 |      1 | 1544715417 |      0 |
............
| bbb6514e757be8477049d3a96fdb0334 |      1 | 1544715419 |      0 |
```

- With automatic user logout:

```
mysql> select * from sessions;
+----------------------------------+--------+------------+--------+
| sessionid                        | userid | lastaccess | status |
+----------------------------------+--------+------------+--------+
| 3e916ece08d99a46e892d76f1dbeb53d |      1 | 1544715465 |      1 |
+----------------------------------+--------+------------+--------+
1 row in set (0.00 sec)
```


