### PR TITLE
filter to hide password and auth_token in logs and exceptions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,16 +57,35 @@ Or use 'with' statement to logout automatically:
         # Get all monitored hosts
         result1 = zapi.host.get(monitored_hosts=1, output='extend')
 
-        # Get all disabled hosts
-        result2 = zapi.do_request('host.get',
-                                {
-                                    'filter': {'status': 1},
-                                    'output': 'extend'
-                                })
+Enable logging:
 
-        # Filter results
-        hostnames1 = [host['host'] for host in result1]
-        hostnames2 = [host['host'] for host in result2['result']]
+.. code:: python
+
+    import sys
+    import logging
+    from pyzabbix.api import ZabbixAPI
+
+    # Create ZabbixAPI class instance
+    logger = logging.getLogger("pyzabbix")
+    logger.setLevel(logging.DEBUG)
+    handler = logging.StreamHandler(sys.stdout)
+    logger.addHandler(handler)
+
+    zapi = ZabbixAPI(url='http://localhost', user='Admin', password='zabbix')
+
+Note that passwords and auth tokens are hidden when raw messages are logged or raised in exceptions ( but not hidden if print() is used):
+
+.. code:: python
+
+    ZabbixAPI.login(Admin,********)
+    Call user.login method
+    urllib2.Request(http://localhost/api_jsonrpc.php, {"jsonrpc": "2.0", "method": "user.login", "params": {"user": "Admin", "password": "********"}, "id": "1"})
+    Response Body: {
+        "jsonrpc": "2.0",
+        "result": "********",
+        "id": "1"
+    }
+
 
 ZabbixSender
 ~~~~~~~~~~~~

--- a/pyzabbix/api.py
+++ b/pyzabbix/api.py
@@ -31,11 +31,12 @@ except ImportError:
     # the urllib.request.
     import urllib.request as urllib2
 
-from .logger import NullHandler
+from .logger import NullHandler, HideSensitiveFilter, HideSensitiveService
 
 null_handler = NullHandler()
 logger = logging.getLogger(__name__)
 logger.addHandler(null_handler)
+logger.addFilter(HideSensitiveFilter())
 
 
 class ZabbixAPIException(Exception):
@@ -49,6 +50,7 @@ class ZabbixAPIException(Exception):
         super(Exception, self).__init__(*args)
         if len(args) == 1 and isinstance(args[0], dict):
             self.error = args[0]
+            self.error['json'] = HideSensitiveService.hide_sensitive(self.error['json'])
             self.message = self.error['message']
             self.code = self.error['code']
             self.data = self.error['data']
@@ -191,7 +193,7 @@ class ZabbixAPI(object):
         :param password: Zabbix user password
         """
 
-        logger.debug("ZabbixAPI.login({0},{1})".format(user, password))
+        logger.debug("ZabbixAPI.login({0},{1})".format(user, HideSensitiveService.HIDEMASK))
 
         self.auth = None
 

--- a/tests/test_hide_sensitive_filter.py
+++ b/tests/test_hide_sensitive_filter.py
@@ -18,8 +18,8 @@ class TestHideSensitiveFilter(unittest.TestCase):
                         HideSensitiveService.HIDEMASK,
                         HideSensitiveService.HIDEMASK)
 
-        self.assertEquals(HideSensitiveService.hide_sensitive(test_message),
-                          expected)
+        self.assertEqual(HideSensitiveService.hide_sensitive(test_message),
+                         expected)
 
     def test_hide_filter_do_not_change_url(self):
 

--- a/tests/test_hide_sensitive_filter.py
+++ b/tests/test_hide_sensitive_filter.py
@@ -1,0 +1,36 @@
+import unittest
+from pyzabbix.logger import HideSensitiveService
+
+
+class TestHideSensitiveFilter(unittest.TestCase):
+
+    def test_hide_filter_multi(self):
+
+        test_message = '"password": "hide_this", ' \
+                       '"result": "0424bd59b807674191e7d77572075f33", ' \
+                       '"result": "do_not_hide_this", ' \
+                       '"auth": "0424bd59b807674191e7d77572075f33"'
+        expected = ('"password": "{}", '
+                    '"result": "{}", '
+                    '"result": "do_not_hide_this", '
+                    '"auth": "{}"').format(
+                        HideSensitiveService.HIDEMASK,
+                        HideSensitiveService.HIDEMASK,
+                        HideSensitiveService.HIDEMASK)
+
+        self.assertEquals(HideSensitiveService.hide_sensitive(test_message),
+                          expected)
+
+    def test_hide_filter_do_not_change_url(self):
+
+        # Filter should not hide 'zabbix' in URL:
+        # https://localhost/zabbix/api_jsonrpc.php
+        test = 'urllib2.Request(https://localhost/zabbix/api_jsonrpc.php,' \
+            '{ ... "params": {"user": "Admin", "password": "zabbix"}, '\
+            '"id": "1"}))'
+        expected = 'urllib2.Request(https://localhost/zabbix/api_jsonrpc.php,'\
+            '{ ... "params": {"user": "Admin", "password": "' + \
+            HideSensitiveService.HIDEMASK + '"}, "id": "1"}))'
+
+        self.assertEqual(HideSensitiveService.hide_sensitive(test),
+                         expected)


### PR DESCRIPTION
Hi, I added logging filter to mask passwords and auth tokens using `********` in case they are printed in logger or exceptions
with help of `logging.Filter` class https://docs.python.org/3/library/logging.html#logging.Filter

Here is an example:
```python
import sys
import logging
from pyzabbix.api import ZabbixAPI

# Create ZabbixAPI class instance
logger = logging.getLogger("pyzabbix")
logger.setLevel(logging.DEBUG)
handler = logging.StreamHandler(sys.stdout)
logger.addHandler(handler)

with ZabbixAPI(url='http://localhost', user='Admin', password='zabbix') as zapi:

    # Get all monitored hosts(intentionally broken call to raise exception)
    result1 = zapi.host2.get(monitored_hosts=1, output='extend')
```
would give you the output:
```python
ZabbixAPI.login(Admin,********)
Call user.login method
urllib2.Request(http://localhost/api_jsonrpc.php, {"jsonrpc": "2.0", "method": "user.login", "params": {"user": "Admin", "password": "********"}, "id": "1"})
Response Body: {
    "jsonrpc": "2.0",
    "result": "********",
    "id": "1"
}
JSON-PRC Server: http://localhost/api_jsonrpc.php
Call host2.get method
urllib2.Request(http://localhost/api_jsonrpc.php, {"jsonrpc": "2.0", "method": "host2.get", "params": {"monitored_hosts": 1, "output": "extend"}, "id": "1", "auth": "********"})
Response Body: {
    "jsonrpc": "2.0",
    "error": {
        "code": -32602,
        "message": "Invalid params.",
        "data": "Incorrect API \"host2\"."
    },
    "id": "1"
}
ZabbixAPI.logout()
Call user.logout method
urllib2.Request(http://localhost/api_jsonrpc.php, {"jsonrpc": "2.0", "method": "user.logout", "params": {}, "id": "1", "auth": "********"})
Response Body: {
    "jsonrpc": "2.0",
    "result": true,
    "id": "1"
}
Traceback (most recent call last):
  File ".\simple_test.py", line 15, in <module>
    result1 = zapi.host2.get(monitored_hosts=1, output='extend')
  File "C:\temp\repos\py-zabbix\pyzabbix\api.py", line 92, in fn
    args or kwargs
  File "C:\temp\repos\py-zabbix\pyzabbix\api.py", line 280, in do_request
    raise ZabbixAPIException(err)
pyzabbix.api.ZabbixAPIException: {'code': -32602, 'message': 'Invalid params.', 'data': 'Incorrect API "host2".', 'json': "{'jsonrpc': '2.0', 'method': 'host2.get', 'params': {'monitored_hosts': 1, 'output': 'extend'}, 'id': '1', 'auth': '********'}"}
```

Logging filter is only applied if logger is used. Otherwise, no additional overhead on string manipulation is expected, as far as I see it.

Please tell what you think. I can refactor this and add tests.

