### PR TITLE
added python3.7 to travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: xenial
+
 sudo: required
 
 services:
@@ -10,6 +12,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 env:
   - ZABBIX_VERSION: 2


### PR DESCRIPTION
note: `dist: xenial` is required for python 3.7 (see https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905)