### PR TITLE
Use socket exceptions instead of bare except

### DIFF
--- a/pyzabbix/sender.py
+++ b/pyzabbix/sender.py
@@ -121,7 +121,7 @@ class ZabbixMetric(object):
             if isinstance(clock, (float, int)):
                 self.clock = int(clock)
             else:
-                raise Exception('Clock must be time in unixtime format')
+                raise ValueError('Clock must be time in unixtime format')
 
     def __repr__(self):
         """Represent detailed ZabbixMetric view."""

--- a/pyzabbix/sender.py
+++ b/pyzabbix/sender.py
@@ -365,7 +365,7 @@ class ZabbixSender(object):
 
         try:
             connection.close()
-        except Exception as err:
+        except socket.error:
             pass
 
         return result
@@ -405,19 +405,19 @@ class ZabbixSender(object):
                              '%d seconds', host_addr, self.timeout)
                 connection.close()
                 raise socket.timeout
-            except Exception as err:
+            except socket.error as err:
                 # In case of error we should close connection, otherwise
                 # we will close it after data will be received.
                 logger.warn('Sending failed: %s', getattr(err, 'msg', str(err)))
                 connection.close()
-                raise Exception(err)
+                raise err
 
             response = self._get_response(connection)
             logger.debug('%s response: %s', host_addr, response)
 
             if response and response.get('response') != 'success':
                 logger.debug('Response error: %s}', response)
-                raise Exception(response)
+                raise socket.error(response)
 
         return response
 

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -1,5 +1,6 @@
 import json
 import os
+import socket
 
 import struct
 
@@ -179,7 +180,7 @@ failed: 10; total: 10; seconds spent: 0.000078"}
     @patch('pyzabbix.sender.socket.socket', autospec=autospec)
     def test_get_response_fail_s_close(self, mock_socket):
         mock_socket.recv.side_effect = (b'IDDQD', self.resp_body)
-        mock_socket.close.side_effect = Exception
+        mock_socket.close.side_effect = socket.error
 
         zs = ZabbixSender()
         result = zs._get_response(mock_socket)
@@ -202,11 +203,11 @@ failed: 10; total: 10; seconds spent: 0.000078"}
     @patch('pyzabbix.sender.socket.socket', autospec=autospec)
     def test_send_sendall_exception(self, mock_socket):
         mock_socket.return_value = mock_socket
-        mock_socket.sendall.side_effect = Exception
+        mock_socket.sendall.side_effect = socket.error
 
         zm = ZabbixMetric('host1', 'key1', 100500, 1457358608)
         zs = ZabbixSender()
-        with self.assertRaises(Exception):
+        with self.assertRaises(socket.error):
             zs.send([zm])
 
     @patch('pyzabbix.sender.socket.socket', autospec=autospec)
@@ -220,5 +221,5 @@ failed: 10; total: 10; seconds spent: 0.000078"}
 
         zm = ZabbixMetric('host1', 'key1', 100500, 1457358608)
         zs = ZabbixSender()
-        with self.assertRaises(Exception):
+        with self.assertRaises(socket.error):
             zs.send([zm])

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -43,7 +43,7 @@ class TestZabbixMetric(TestCase):
         self.assertEqual(zm.clock, 1457358608)
 
     def test_init_err(self):
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             ZabbixMetric('host1', 'key1', 100500, '1457358608.01')
 
     def test_repr(self):


### PR DESCRIPTION
This fix allows to catch sender exceptions as generic IOError exceptions (python 3) or socket exceptions (python 2).

Signed-off-by: Boris HUISGEN <bhuisgen@hbis.fr>