### PR TITLE
fix typo in timeout error message

### DIFF
--- a/pyzabbix/sender.py
+++ b/pyzabbix/sender.py
@@ -409,7 +409,7 @@ class ZabbixSender(object):
                 connection.sendall(packet)
             except socket.timeout:
                 logger.error('Sending failed: Connection to %s timed out after'
-                             '%d seconds', host_addr, self.timeout)
+                             ' %d seconds', host_addr, self.timeout)
                 connection.close()
                 raise socket.timeout
             except socket.error as err:


### PR DESCRIPTION
missing space before timeout value