### PR TITLE
Zabbix user.login api update

### DIFF
--- a/pyzabbix/api.py
+++ b/pyzabbix/api.py
@@ -205,9 +205,9 @@ class ZabbixAPI(object):
         self.auth = None
 
         if self.use_authenticate:
-            self.auth = self.user.authenticate(user=user, password=password)
+            self.auth = self.user.authenticate(username=user, password=password)
         else:
-            self.auth = self.user.login(user=user, password=password)
+            self.auth = self.user.login(username=user, password=password)
 
     def _logout(self):
         """Do logout from zabbix server."""


### PR DESCRIPTION
Zabbix update the `user.login` api which is no longer get the `user` parameter The user parameter has deprecated warning at version 6.0 - https://www.zabbix.com/documentation/6.0/en/manual/api/reference/user/login  Which is fully removed in the latest version - https://www.zabbix.com/documentation/current/en/manual/api/reference/user/login